### PR TITLE
Add GitHub OAuth endpoints and environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# GitHub OAuth application credentials
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_REDIRECT_URI=http://localhost:3000/github/callback

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 웹 기반 알골 키우기 게임의 클라이언트 프로토타입입니다. 깃허브 계정으로 로그인하면 알고냥이의 생활 공간으로 진입해 밥을 주고, 청소하고, 함께 시간을 보낼 수 있습니다.
 
+## 최근 작업 요약
+
+- GitHub OAuth 인증을 처리하는 전용 라우터(`routes/github.js`)를 추가하여 로그인, 콜백, 사용자 정보 조회 엔드포인트를 구성했습니다.
+- Express 앱 초기 구동 시 `dotenv`를 통해 GitHub OAuth 클라이언트 설정을 불러오도록 구성했습니다.
+- 필수 GitHub OAuth 환경 변수(`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_REDIRECT_URI`)를 `.env.example`에 명시했습니다.
+
 ## 주요 기능
 
 - **GitHub 로그인**: 깃허브 OAuth 버튼으로 로그인하면 캐릭터 방으로 입장합니다. 데모 모드 버튼으로는 계정 없이 체험할 수 있습니다.

--- a/app.js
+++ b/app.js
@@ -1,3 +1,9 @@
+try {
+  require('dotenv').config();
+} catch (error) {
+  console.warn('dotenv not installed; skipping .env loading');
+}
+
 var createError = require('http-errors');
 var express = require('express');
 var path = require('path');
@@ -55,7 +61,7 @@ app.use(function(err, req, res, next) {
   // render the error page
   res.status(err.status || 500);
   res.render('error');
-  console.log(req.session)
+  console.log(req.session);
 });
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.12.2",
     "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "randomstring": "^1.3.1",
     "vue-router": "^4.5.1"
   }

--- a/routes/github.js
+++ b/routes/github.js
@@ -1,0 +1,155 @@
+const express = require('express');
+const axios = require('axios');
+const randomstring = require('randomstring');
+
+const router = express.Router();
+
+const STATE_COOKIE_NAME = 'github_oauth_state';
+const TOKEN_COOKIE_NAME = 'github_token';
+const STATE_TTL = 5 * 60 * 1000; // 5 minutes
+const pendingStates = new Map();
+
+function pruneStates() {
+  const now = Date.now();
+  for (const [state, createdAt] of pendingStates) {
+    if (now - createdAt > STATE_TTL) {
+      pendingStates.delete(state);
+    }
+  }
+}
+
+router.get('/login', (req, res) => {
+  const { GITHUB_CLIENT_ID, GITHUB_REDIRECT_URI } = process.env;
+
+  if (!GITHUB_CLIENT_ID || !GITHUB_REDIRECT_URI) {
+    return res
+      .status(500)
+      .json({ error: 'GitHub OAuth is not configured properly.' });
+  }
+
+  pruneStates();
+
+  const state = randomstring.generate(32);
+  pendingStates.set(state, Date.now());
+
+  res.cookie(STATE_COOKIE_NAME, state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: STATE_TTL,
+  });
+
+  const params = new URLSearchParams({
+    client_id: GITHUB_CLIENT_ID,
+    redirect_uri: GITHUB_REDIRECT_URI,
+    scope: 'read:user user:email',
+    state,
+    allow_signup: 'true',
+  });
+
+  res.redirect(`https://github.com/login/oauth/authorize?${params.toString()}`);
+});
+
+router.get('/callback', async (req, res) => {
+  const { code, state } = req.query;
+  const storedState = req.cookies ? req.cookies[STATE_COOKIE_NAME] : undefined;
+
+  pruneStates();
+
+  if (!code || !state) {
+    return res.status(400).json({ error: 'Missing code or state parameter.' });
+  }
+
+  if (!storedState || storedState !== state || !pendingStates.has(state)) {
+    return res.status(400).json({ error: 'Invalid OAuth state.' });
+  }
+
+  pendingStates.delete(state);
+  res.clearCookie(STATE_COOKIE_NAME);
+
+  const { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URI } =
+    process.env;
+
+  if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET || !GITHUB_REDIRECT_URI) {
+    return res
+      .status(500)
+      .json({ error: 'GitHub OAuth is not configured properly.' });
+  }
+
+  try {
+    const tokenResponse = await axios.post(
+      'https://github.com/login/oauth/access_token',
+      {
+        client_id: GITHUB_CLIENT_ID,
+        client_secret: GITHUB_CLIENT_SECRET,
+        code,
+        redirect_uri: GITHUB_REDIRECT_URI,
+        state,
+      },
+      {
+        headers: {
+          Accept: 'application/json',
+        },
+      }
+    );
+
+    const accessToken = tokenResponse.data && tokenResponse.data.access_token;
+
+    if (!accessToken) {
+      return res
+        .status(500)
+        .json({ error: 'Failed to retrieve access token from GitHub.' });
+    }
+
+    res.cookie(TOKEN_COOKIE_NAME, accessToken, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+    });
+
+    return res.json({ success: true });
+  } catch (error) {
+    const status = error.response ? error.response.status : 500;
+    const message =
+      (error.response && error.response.data) ||
+      error.message ||
+      'Failed to exchange authorization code.';
+
+    console.error('GitHub OAuth callback error:', message);
+
+    return res.status(status).json({ error: 'Failed to exchange authorization code.' });
+  }
+});
+
+router.get('/me', async (req, res) => {
+  const token = req.cookies ? req.cookies[TOKEN_COOKIE_NAME] : undefined;
+
+  if (!token) {
+    return res.status(401).json({ error: 'Not authenticated.' });
+  }
+
+  try {
+    const userResponse = await axios.get('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'Idle-App',
+      },
+    });
+
+    return res.json(userResponse.data);
+  } catch (error) {
+    const status = error.response ? error.response.status : 500;
+
+    if (status === 401) {
+      res.clearCookie(TOKEN_COOKIE_NAME);
+      return res.status(401).json({ error: 'Invalid or expired token.' });
+    }
+
+    console.error('GitHub user fetch error:', error.message || error);
+    return res.status(500).json({ error: 'Failed to fetch user profile.' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add a GitHub OAuth router that handles login, callback, and profile retrieval flows
- load environment variables via dotenv and document required GitHub OAuth settings
- add a Korean-language summary of the recent GitHub OAuth work to the README

## Testing
- npm install dotenv *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e8bc08e5d08329859719b3318332c7